### PR TITLE
Switch to opensearch

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -19,13 +19,14 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
 
   elasticsearch:
-    image: "elasticsearch:7.9.3"
+    image: "opensearchproject/opensearch:1.2.4"
     ports:
       - "9200:9200"
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
     environment:
       - "discovery.type=single-node"
+      - "DISABLE_SECURITY_PLUGIN=true"
 
   s3:
     image: "localstack/localstack:0.12.9.1@sha256:bf1685501c6b3f75a871b5319857b2cc88158eb80a225afe8abef9a935d5148a"


### PR DESCRIPTION
https://trello.com/c/rjASqjwT/2398-migrate-from-elasticsearch-to-opensearch

Part of the preparation to migrate off elasticsearch. GOV.UK PaaS will drop support for elasticsearch soon. See https://docs.cloud.service.gov.uk/deploying_services/opensearch/#migrating-from-elasticsearch.

We need to disable security so that we can continue accessing it via HTTP. Otherwise, we'd need to start using HTTPS. I think it uses a self-signed certificate, so we'd need to make a lot of changes to get that to work.

This is a copy of https://github.com/Crown-Commercial-Service/ccs-digitalmarketplace-runner/pull/47